### PR TITLE
Update docker-compose.pull-dog.yml

### DIFF
--- a/docker-compose.pull-dog.yml
+++ b/docker-compose.pull-dog.yml
@@ -1,4 +1,3 @@
-
 services:
   portainer:
     image: portainerci/portainer:$PORTAINER_TAG

--- a/docker-compose.pull-dog.yml
+++ b/docker-compose.pull-dog.yml
@@ -1,4 +1,3 @@
-version: '3'
 
 services:
   portainer:


### PR DESCRIPTION
Fixed verion obsolete confusing warning by deleteing Version line

closes #0 <!-- Github issue number (remove if unknown) -->
closes [CE-0] <!-- Jira link number (remove if unknown). Please also add the same [CE-XXX] at the back of the PR title -->

### Changes:
